### PR TITLE
Return a nil UIImage in renderAtSize: if empty size

### DIFF
--- a/OHPDFImage/OHVectorImage.m
+++ b/OHPDFImage/OHVectorImage.m
@@ -147,6 +147,13 @@
 
 - (UIImage*)renderAtSize:(CGSize)size
 {
+    if (size.width <= 0
+        ||
+        size.height <= 0)
+    {
+        return nil ;
+    }
+
     CGSize scale = [self scaleForSize:size];
     UIEdgeInsets scaledInsets = (UIEdgeInsets){
         .top    = self.insets.top    * scale.height,


### PR DESCRIPTION
Returning nil when the size is zero in one of the directions.